### PR TITLE
feat: add multi-SIMD-level compilation support

### DIFF
--- a/.github/workflows/build-and-upload-packages.yml
+++ b/.github/workflows/build-and-upload-packages.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install and switch to GCC 10
         run: |
           sudo apt update
-          sudo apt install -y gcc-10 g++-10
+          sudo apt install -y gcc-10 g++-10 cmake patchelf
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
           sudo update-alternatives --set gcc /usr/bin/gcc-10
         shell: bash

--- a/README.md
+++ b/README.md
@@ -30,7 +30,22 @@ source:
   branch: "main"              # optional
   subdirectory: "matlab"      # optional: extract specific subdir
   remove_dirs: [tests, docs]  # optional: remove after clone
+
+simd: true                    # optional: build x86_64 v1-v4 SIMD variants
 ```
+
+#### SIMD support
+
+Packages with `simd: true` are compiled once per x86_64 microarchitecture level (v1 through v4) on Linux and Windows. At install time, `mip` detects the host CPU and picks the fastest compatible variant.
+
+| Level | GCC flag | MSVC flag | Features |
+|-------|----------|-----------|----------|
+| v1 | `-march=x86-64` | `/arch:SSE2` | Baseline |
+| v2 | `-march=x86-64-v2` | `/arch:SSE4.2` | SSE4.2, SSSE3, POPCNT |
+| v3 | `-march=x86-64-v3` | `/arch:AVX2` | AVX2, FMA, BMI1/2 |
+| v4 | `-march=x86-64-v4` | `/arch:AVX512` | AVX-512F/BW/CD/DQ/VL |
+
+Packages without `simd: true` (the default) are built once per platform as before. macOS builds are unaffected — SIMD variants are only produced for `linux_x86_64` and `windows_x86_64`.
 
 ### mip.yaml — package metadata
 

--- a/scripts/assemble_index.py
+++ b/scripts/assemble_index.py
@@ -32,11 +32,12 @@ def _version_sort_key(version_str):
 
 
 def _package_sort_key(pkg):
-    """Sort key for packages: by name (case-insensitive), then version, then architecture."""
+    """Sort key for packages: by name (case-insensitive), then version, then architecture, then cpu_level."""
     return (
         pkg.get('name', '').lower(),
         _version_sort_key(pkg.get('version', '0')),
         pkg.get('architecture', ''),
+        pkg.get('cpu_level', ''),
     )
 
 
@@ -247,7 +248,10 @@ class IndexAssembler:
                     name_cell = escape(name)
 
                 architecture = pkg.get('architecture', 'any')
+                cpu_level = pkg.get('cpu_level', '')
                 platform_info = f"architecture={architecture}"
+                if cpu_level:
+                    platform_info += f", cpu_level={cpu_level}"
 
                 download_links = []
                 if mhl_url:

--- a/scripts/build_targets.py
+++ b/scripts/build_targets.py
@@ -33,9 +33,9 @@ LTO_LINK_FLAG_MSVC = "/LTCG"
 # GCC -march / -mtune per psABI level
 LINUX_X86_64_CPU_PROFILES = {
     "x86_64_v1": {"march": "x86-64",    "mtune": "generic"},
-    "x86_64_v2": {"march": "x86-64-v2", "mtune": "nehalem"},
-    "x86_64_v3": {"march": "x86-64-v3", "mtune": "haswell"},
-    "x86_64_v4": {"march": "x86-64-v4", "mtune": "skylake-avx512"},
+    "x86_64_v2": {"march": "x86-64-v2", "mtune": "generic"},
+    "x86_64_v3": {"march": "x86-64-v3", "mtune": "generic"},
+    "x86_64_v4": {"march": "x86-64-v4", "mtune": "generic"},
 }
 
 # MSVC /arch / /favor per psABI level
@@ -65,11 +65,8 @@ def get_compiler_env(architecture: str, cpu_level: str) -> Dict[str, str]:
 
     if architecture == "linux_x86_64":
         p = LINUX_X86_64_CPU_PROFILES[cpu_level]
-        # -fno-semantic-interposition: safe for shared libs (MEX), major inlining win
-        # -fno-plt: avoids PLT indirection for external calls
         base = (
             f"-O3 -march={p['march']} -mtune={p['mtune']} {LTO_FLAG_GCC}"
-            " -fno-semantic-interposition -fno-plt"
         )
         env.update({
             "MIP_MARCH": p["march"],

--- a/scripts/build_targets.py
+++ b/scripts/build_targets.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+CPU-level build target definitions and compiler flag mappings.
+
+Packages with `simd: true` in their recipe.yaml are built once per CPU level
+(x86_64_v1 through v4) on linux_x86_64 and windows_x86_64.  This module
+centralises the level definitions, compiler-flag profiles, and helper
+functions consumed by prepare_packages.py.
+
+CI-only — never runs on end-user machines.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+CPU_LEVELS = (
+    "x86_64_v1",
+    "x86_64_v2",
+    "x86_64_v3",
+    "x86_64_v4",
+)
+
+CPU_LEVEL_ORDER = {level: idx for idx, level in enumerate(CPU_LEVELS, start=1)}
+
+SIMD_ARCHITECTURES = {"linux_x86_64", "windows_x86_64"}
+
+LTO_FLAG_GCC = "-flto=auto"
+LTO_FLAG_MSVC = "/GL"
+LTO_LINK_FLAG_MSVC = "/LTCG"
+
+# GCC -march / -mtune per psABI level
+LINUX_X86_64_CPU_PROFILES = {
+    "x86_64_v1": {"march": "x86-64",    "mtune": "generic"},
+    "x86_64_v2": {"march": "x86-64-v2", "mtune": "nehalem"},
+    "x86_64_v3": {"march": "x86-64-v3", "mtune": "haswell"},
+    "x86_64_v4": {"march": "x86-64-v4", "mtune": "skylake-avx512"},
+}
+
+# MSVC /arch / /favor per psABI level
+WINDOWS_X86_64_CPU_PROFILES = {
+    "x86_64_v1": {"arch_flag": "/arch:SSE2",   "favor_flag": "/favor:blend"},
+    "x86_64_v2": {"arch_flag": "/arch:SSE4.2",  "favor_flag": "/favor:blend"},
+    "x86_64_v3": {"arch_flag": "/arch:AVX2",    "favor_flag": "/favor:blend"},
+    "x86_64_v4": {"arch_flag": "/arch:AVX512",  "favor_flag": "/favor:blend"},
+}
+
+
+def is_simd_architecture(architecture: str) -> bool:
+    """Return True if *architecture* supports per-level SIMD builds."""
+    return architecture in SIMD_ARCHITECTURES
+
+
+def get_compiler_env(architecture: str, cpu_level: str) -> Dict[str, str]:
+    """Return environment variables that set compiler flags for *cpu_level*.
+
+    These are exported before compile scripts run so that cmake / mex / gcc
+    pick up the correct -march or /arch flags automatically.
+    """
+    if cpu_level not in CPU_LEVELS:
+        raise ValueError(f"Unknown cpu_level: {cpu_level}")
+
+    env: Dict[str, str] = {"MIP_CPU_LEVEL": cpu_level}
+
+    if architecture == "linux_x86_64":
+        p = LINUX_X86_64_CPU_PROFILES[cpu_level]
+        # -fno-semantic-interposition: safe for shared libs (MEX), major inlining win
+        # -fno-plt: avoids PLT indirection for external calls
+        base = (
+            f"-O3 -march={p['march']} -mtune={p['mtune']} {LTO_FLAG_GCC}"
+            " -fno-semantic-interposition -fno-plt"
+        )
+        env.update({
+            "MIP_MARCH": p["march"],
+            "MIP_MTUNE": p["mtune"],
+            "CFLAGS": base,
+            "CXXFLAGS": base,
+            "FFLAGS": f"-O3 -march={p['march']} -mtune={p['mtune']} {LTO_FLAG_GCC}",
+            "LDFLAGS": LTO_FLAG_GCC,
+        })
+
+    elif architecture == "windows_x86_64":
+        p = WINDOWS_X86_64_CPU_PROFILES[cpu_level]
+        cl_flags = f"/O2 /Oi {p['arch_flag']} {p['favor_flag']} {LTO_FLAG_MSVC}".strip()
+        env.update({
+            "CL": cl_flags,
+            "_LINK_": LTO_LINK_FLAG_MSVC,
+        })
+
+    return env

--- a/scripts/bundle_packages.m
+++ b/scripts/bundle_packages.m
@@ -46,9 +46,47 @@ for i = 1:length(items)
     fprintf('\n--- Bundling: %s ---\n', items(i).name);
 
     try
+        % Apply compiler environment from .compiler_env (SIMD builds)
+        % Parse JSON manually to preserve keys like _LINK_ that jsondecode
+        % mangles (MATLAB struct fields cannot start with underscore).
+        originalEnv = containers.Map('KeyType','char','ValueType','char');
+        compilerEnvFile = fullfile(pkgDir, '.compiler_env');
+        if exist(compilerEnvFile, 'file')
+            envMap = readJsonEnvFile(compilerEnvFile);
+            envKeys = keys(envMap);
+            for j = 1:length(envKeys)
+                k = envKeys{j};
+                originalEnv(k) = getenv(k);
+                setenv(k, envMap(k));
+                fprintf('  Setting %s=%s\n', k, envMap(k));
+            end
+        end
+
+        % Read cpu_level (if present)
+        cpuLevel = '';
+        cpuLevelFile = fullfile(pkgDir, '.cpu_level');
+        if exist(cpuLevelFile, 'file')
+            cpuLevel = strtrim(fileread(cpuLevelFile));
+            fprintf('  CPU level: %s\n', cpuLevel);
+        end
+
+        % Bundle (standard args — no --cpu-level, works with upstream mip)
         mip.bundle(pkgDir, '--output', outputDir, '--arch', architecture);
+
+        % If SIMD variant, rename .mhl and .mip.json to include cpu_level
+        if ~isempty(cpuLevel)
+            renameBundleWithCpuLevel(outputDir, pkgDir, cpuLevel);
+        end
+
         bundled = bundled + 1;
+
+        % Restore compiler environment
+        restoreEnv(originalEnv);
     catch ME
+        % Restore compiler environment on failure too
+        if exist('originalEnv', 'var')
+            restoreEnv(originalEnv);
+        end
         fprintf('Error bundling %s: %s\n', items(i).name, ME.message);
         failed = failed + 1;
     end
@@ -60,4 +98,77 @@ fprintf('Failed: %d\n', failed);
 
 if failed > 0
     error('mip:bundleFailed', '%d package(s) failed to bundle', failed);
+end
+
+
+function restoreEnv(envMap)
+%RESTOREENV  Restore environment variables from a containers.Map.
+if ~isa(envMap, 'containers.Map')
+    return
+end
+envKeys = keys(envMap);
+for j = 1:length(envKeys)
+    setenv(envKeys{j}, envMap(envKeys{j}));
+end
+end
+
+
+function renameBundleWithCpuLevel(outputDir, ~, cpuLevel)
+%RENAMEBUNDLEWITHCPULEVEL  Rename .mhl and .mip.json to include cpu_level.
+%
+%   mip.bundle produces: name-version-arch.mhl
+%   We rename to:        name-version-arch-cpuLevel.mhl
+%   Also patches cpu_level into the .mip.json metadata.
+
+% Find .mhl files that don't already have any cpu_level suffix.
+% cpu_level suffixes look like: -x86_64_v1.mhl, -x86_64_v2.mhl, etc.
+cpuLevelPattern = '-x86_64_v';
+mhlFiles = dir(fullfile(outputDir, '*.mhl'));
+for j = 1:length(mhlFiles)
+    oldName = mhlFiles(j).name;
+    if endsWith(oldName, '.mip.json')
+        continue
+    end
+    % Skip if already has any cpu_level suffix
+    if contains(oldName, cpuLevelPattern)
+        continue
+    end
+
+    % Insert -cpuLevel before .mhl
+    newName = strrep(oldName, '.mhl', ['-' cpuLevel '.mhl']);
+    oldPath = fullfile(outputDir, oldName);
+    newPath = fullfile(outputDir, newName);
+    movefile(oldPath, newPath);
+    fprintf('  Renamed: %s -> %s\n', oldName, newName);
+
+    % Also rename and patch the .mip.json companion
+    oldJsonPath = [oldPath '.mip.json'];
+    newJsonPath = [newPath '.mip.json'];
+    if exist(oldJsonPath, 'file')
+        fid = fopen(oldJsonPath, 'r');
+        metadata = jsondecode(fread(fid, '*char')');
+        fclose(fid);
+        metadata.cpu_level = cpuLevel;
+        fid = fopen(newJsonPath, 'w');
+        fwrite(fid, jsonencode(metadata));
+        fclose(fid);
+        if ~strcmp(oldJsonPath, newJsonPath)
+            delete(oldJsonPath);
+        end
+        fprintf('  Patched: %s\n', [newName '.mip.json']);
+    end
+end
+end
+
+
+function envMap = readJsonEnvFile(filepath)
+%READJSONENVFILE  Parse a JSON key-value file into a containers.Map.
+%   Avoids jsondecode which mangles keys starting with underscore.
+envMap = containers.Map('KeyType','char','ValueType','char');
+text = fileread(filepath);
+% Simple regex extraction of "key": "value" pairs
+tokens = regexp(text, '"([^"]+)"\s*:\s*"([^"]*)"', 'tokens');
+for j = 1:length(tokens)
+    envMap(tokens{j}{1}) = tokens{j}{2};
+end
 end

--- a/scripts/channel_config.py
+++ b/scripts/channel_config.py
@@ -41,10 +41,13 @@ def get_base_url(release_tag):
 def release_tag_from_mhl(mhl_filename):
     """Extract the release tag (name-version) from an .mhl filename.
 
-    Filename format: {name}-{version}-{architecture}.mhl
-    Package names use underscores, never hyphens, so the first hyphen
-    separates name from version, and the last hyphen separates version
-    from architecture.
+    Filename formats:
+      {name}-{version}-{architecture}.mhl
+      {name}-{version}-{architecture}-{cpu_level}.mhl
+
+    Package names use underscores (never hyphens) and versions use dots,
+    so hyphens appear only as segment delimiters.  The first two segments
+    are always name and version.
     """
     basename = mhl_filename
     if basename.endswith('.mip.json'):
@@ -52,8 +55,7 @@ def release_tag_from_mhl(mhl_filename):
     if basename.endswith('.mhl'):
         basename = basename[:-4]
 
-    # Split on last hyphen to get architecture, rest is name-version
-    last_hyphen = basename.rfind('-')
-    if last_hyphen == -1:
+    parts = basename.split('-')
+    if len(parts) < 2:
         return basename
-    return basename[:last_hyphen]
+    return '-'.join(parts[:2])

--- a/scripts/prepare_packages.py
+++ b/scripts/prepare_packages.py
@@ -25,6 +25,7 @@ import argparse
 import requests
 import yaml
 from channel_config import get_github_repo, get_base_url, release_tag_from_mhl
+from build_targets import CPU_LEVELS, is_simd_architecture, get_compiler_env
 
 
 def _rmtree_on_error(func, path, exc_info):
@@ -350,58 +351,111 @@ class PackagePreparer:
             else:
                 effective_arch = 'any'
 
-            # Build the .mhl filename for cache check
             version = mip_yaml.get('version', release_version)
-            mhl_filename = (f"{mip_yaml['name']}-{version}-"
-                            f"{effective_arch}.mhl")
 
-            # Check cache
-            if not self.force and check_existing_package(
-                    mhl_filename, source_hash, mip_yaml):
-                print(f"  Skipping - package already up to date")
-                continue
+            # Determine CPU level variants to build
+            use_simd = (recipe.get('simd', False)
+                        and is_simd_architecture(self.architecture))
+            cpu_levels = list(CPU_LEVELS) if use_simd else [None]
 
-            if self.dry_run:
-                print(f"  [DRY RUN] Would prepare {package_name}")
-                continue
-
-            # Create output directory: build/prepared/{name}-{version}/
-            output_name = f"{mip_yaml['name']}-{version}"
-            output_path = os.path.join(self.output_dir, output_name)
-
-            if os.path.exists(output_path):
-                shutil.rmtree(output_path, onerror=_rmtree_on_error)
-            os.makedirs(output_path)
-
-            try:
-                # Fetch source into output directory
-                self._fetch_source(recipe, output_path)
-                # Overlay channel files
-                overlay_channel_files(release_folder, output_path)
-
-                # Write source_hash for mip bundle to include in mip.json
-                hash_file = os.path.join(output_path, '.source_hash')
-                with open(hash_file, 'w') as f:
-                    f.write(source_hash)
-
-                # Write raw git commit hash if available
-                if remote_hashes:
-                    commit_hash_file = os.path.join(
-                        output_path, '.commit_hash')
-                    with open(commit_hash_file, 'w') as f:
-                        f.write(remote_hashes[0])
-
-                print(f"  Prepared: {output_path}")
-
-            except Exception as e:
-                print(f"  Error preparing package: {e}")
-                import traceback
-                traceback.print_exc()
-                if os.path.exists(output_path):
-                    shutil.rmtree(output_path, onerror=_rmtree_on_error)
-                return False
+            # For SIMD packages, clone source once and copy for each variant
+            # to avoid redundant git clones.
+            first_prepared_path = None
+            for cpu_level in cpu_levels:
+                ok = self._prepare_variant(
+                    recipe=recipe,
+                    release_folder=release_folder,
+                    mip_yaml=mip_yaml,
+                    effective_arch=effective_arch,
+                    version=version,
+                    source_hash=source_hash,
+                    remote_hashes=remote_hashes,
+                    cpu_level=cpu_level,
+                    copy_from=first_prepared_path,
+                )
+                if not ok:
+                    return False
+                # After the first successful variant, record its path
+                # so subsequent variants can copy instead of cloning.
+                if first_prepared_path is None and not self.dry_run:
+                    suffix = f"-{cpu_level}" if cpu_level else ""
+                    first_prepared_path = os.path.join(
+                        self.output_dir,
+                        f"{mip_yaml['name']}-{version}{suffix}")
+                    if not os.path.isdir(first_prepared_path):
+                        first_prepared_path = None
 
         return True
+
+    def _prepare_variant(self, *, recipe, release_folder, mip_yaml,
+                         effective_arch, version, source_hash,
+                         remote_hashes, cpu_level, copy_from=None):
+        """Prepare one variant (one cpu_level or None for non-SIMD).
+
+        When copy_from is set, copies that directory instead of cloning
+        the source again — avoids redundant git clones for SIMD variants.
+        """
+        name = mip_yaml['name']
+
+        # Build .mhl filename (with optional cpu_level suffix)
+        if cpu_level:
+            mhl_filename = f"{name}-{version}-{effective_arch}-{cpu_level}.mhl"
+            output_name = f"{name}-{version}-{cpu_level}"
+            print(f"  Variant: {effective_arch} / {cpu_level}")
+        else:
+            mhl_filename = f"{name}-{version}-{effective_arch}.mhl"
+            output_name = f"{name}-{version}"
+
+        # Check cache
+        if not self.force and check_existing_package(
+                mhl_filename, source_hash, mip_yaml):
+            print(f"  Skipping - package already up to date")
+            return True
+
+        if self.dry_run:
+            print(f"  [DRY RUN] Would prepare {output_name}")
+            return True
+
+        output_path = os.path.join(self.output_dir, output_name)
+        if os.path.exists(output_path):
+            shutil.rmtree(output_path, onerror=_rmtree_on_error)
+
+        try:
+            if copy_from and os.path.isdir(copy_from):
+                print(f"  Copying from {os.path.basename(copy_from)}...")
+                shutil.copytree(copy_from, output_path)
+            else:
+                os.makedirs(output_path)
+                self._fetch_source(recipe, output_path)
+                overlay_channel_files(release_folder, output_path)
+
+            # Write source_hash
+            with open(os.path.join(output_path, '.source_hash'), 'w') as f:
+                f.write(source_hash)
+
+            # Write raw git commit hash if available
+            if remote_hashes:
+                with open(os.path.join(output_path, '.commit_hash'), 'w') as f:
+                    f.write(remote_hashes[0])
+
+            # Write SIMD metadata for bundle_packages.m
+            if cpu_level:
+                with open(os.path.join(output_path, '.cpu_level'), 'w') as f:
+                    f.write(cpu_level)
+                compiler_env = get_compiler_env(effective_arch, cpu_level)
+                with open(os.path.join(output_path, '.compiler_env'), 'w') as f:
+                    json.dump(compiler_env, f, indent=2)
+
+            print(f"  Prepared: {output_path}")
+            return True
+
+        except Exception as e:
+            print(f"  Error preparing package: {e}")
+            import traceback
+            traceback.print_exc()
+            if os.path.exists(output_path):
+                shutil.rmtree(output_path, onerror=_rmtree_on_error)
+            return False
 
     def prepare_all(self):
         """Prepare all packages."""


### PR DESCRIPTION
Packages with `simd: true` in recipe.yaml are built for x86_64 v1-v4 on linux and windows. Non-SIMD packages (the default) build once as before.
