### PR TITLE
allow '-' in canonical package names; encode as '_' in filenames

### DIFF
--- a/scripts/channel_config.py
+++ b/scripts/channel_config.py
@@ -42,9 +42,12 @@ def release_tag_from_mhl(mhl_filename):
     """Extract the release tag (name-version) from an .mhl filename.
 
     Filename format: {name}-{version}-{architecture}.mhl
-    Package names use underscores, never hyphens, so the first hyphen
-    separates name from version, and the last hyphen separates version
-    from architecture.
+
+    A canonical package name may contain '-' (e.g. 'foo-bar'), but '-'
+    is the field separator in the filename, so the name is always
+    encoded with '_' in the filename (e.g. 'foo_bar-1.0-any.mhl').
+    The last hyphen therefore separates version from architecture, and
+    the remainder is the release tag '{name-as-underscores}-{version}'.
     """
     basename = mhl_filename
     if basename.endswith('.mip.json'):

--- a/scripts/prepare_packages.py
+++ b/scripts/prepare_packages.py
@@ -262,8 +262,8 @@ class PackagePreparer:
         package_name = os.path.basename(package_dir)
         print(f"\nProcessing package: {package_name}")
 
-        if '-' in package_name:
-            print(f"  Error: Package name contains hyphens. Use underscores.")
+        if package_name != package_name.lower():
+            print(f"  Error: Package name must be lowercase.")
             return False
 
         releases_path = os.path.join(package_dir, 'releases')
@@ -351,9 +351,12 @@ class PackagePreparer:
             else:
                 effective_arch = 'any'
 
-            # Build the .mhl filename for cache check
+            # Build the .mhl filename for cache check. Canonical package
+            # names may contain '-', but the filename uses '-' as a field
+            # separator, so encode the name with '_' in the filename.
             version = mip_yaml.get('version', release_version)
-            mhl_filename = (f"{mip_yaml['name']}-{version}-"
+            name_for_filename = mip_yaml['name'].replace('-', '_')
+            mhl_filename = (f"{name_for_filename}-{version}-"
                             f"{effective_arch}.mhl")
 
             # Check cache


### PR DESCRIPTION
## Summary

- Canonical package names are now required to be lowercase but may contain either `-` or `_` — matching the upstream project's spelling (e.g. `aabb-tree`). The `mip` CLI already resolves user input case-insensitively with `-`/`_` treated as equivalent (`mip.name.normalize`), so flexibility on the canonical side doesn't change the user experience.
- Because `-` is the field separator in the `{name}-{version}-{arch}.mhl` filename scheme, `-` in the name is encoded as `_` **in the filename only**. The canonical name in `mip.yaml`, the generated `.mip.json`, and the channel index is preserved verbatim.

### Changes

- `scripts/prepare_packages.py`
  - Reject non-lowercase names (was: reject any name containing `-`).
  - Swap `-` → `_` when building `mhl_filename` for the cache check.
- `scripts/channel_config.py`
  - Update `release_tag_from_mhl` docstring to explain the filename-encoding convention.

### Companion changes outside this repo

- [`mip-org/mip`](https://github.com/mip-org/mip): `+mip/bundle.m` needs the matching `-` → `_` swap when constructing the bundle filename (companion PR forthcoming).
- `mip-staging` and `mip-core`: will be synced from this template after merge.

## Test plan

- [ ] CI passes
- [ ] Verify adding a package with a hyphenated canonical name (e.g. `foo-bar`) under `packages/foo-bar/` produces `foo_bar-<version>-<arch>.mhl` with `name: foo-bar` inside the bundled `.mip.json`.
- [ ] Verify adding a package with an uppercase directory name is rejected with the new "must be lowercase" error.
- [ ] Verify `release_tag_from_mhl("foo_bar-1.0-any.mhl")` still returns `"foo_bar-1.0"`.