### PR TITLE
Channel version rules: drop recipe.yaml version, validate release dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ source:
 ```yaml
 name: my_package
 description: "What this package does"
-version: "1.0.0"
+version: "1.0.0"           # optional; blank or numeric
 license: "MIT"
 dependencies: []
 
@@ -56,7 +56,25 @@ builds:
     compile_script: compile.m
 ```
 
-Package names must use underscores (not hyphens). The version in the YAML must match the release folder name.
+Package names must use underscores (not hyphens).
+
+### Version rules
+
+The package version is the release directory name under
+`packages/<name>/<version>/`. The `version` field in `mip.yaml` is optional;
+when present it must be either blank or numeric (e.g. `1.2.3`). Non-numeric
+values like branch names belong in the directory name, not in `mip.yaml`.
+`recipe.yaml` does not carry a `version` field.
+
+The release directory name must be one of:
+
+- the numeric `version` in `mip.yaml`,
+- the `source.branch` named in `recipe.yaml`, or
+- any string, when `mip.yaml`'s `version` is blank/missing.
+
+So `packages/chebfun/5.7.0/` (numeric version matches `mip.yaml`) and
+`packages/my_package/main/` (branch matches `source.branch: main`, with
+`mip.yaml` version blank) are both valid.
 
 ## How it works
 

--- a/scripts/prepare_packages.py
+++ b/scripts/prepare_packages.py
@@ -162,9 +162,10 @@ def is_numeric_version(s):
     return all(p.isdigit() for p in parts) and len(parts) >= 1
 
 
-def validate_and_apply_version(mip_yaml_path, recipe, release_version):
-    """Validate channel version rules and write the release-dir version into
-    mip.yaml when mip.yaml's version is blank or missing.
+def validate_channel_version_rules(mip_yaml_path, recipe, release_version):
+    """Validate channel version rules. The release-dir version is passed to
+    the bundler via a side file (.release_version) rather than being written
+    into mip.yaml, so mip.yaml stays as authored.
 
     Rules:
     - recipe.yaml must not contain a top-level 'version' field.
@@ -194,17 +195,10 @@ def validate_and_apply_version(mip_yaml_path, recipe, release_version):
             f"Non-numeric values (e.g. branch names) belong in the release "
             f"directory name, not in mip.yaml.")
 
-    if mv:
-        if release_version != mv and release_version != source_branch:
-            raise ValueError(
-                f"Release directory {release_version!r} must equal mip.yaml "
-                f"version {mv!r} or recipe source.branch {source_branch!r}.")
-    else:
-        # Blank/missing mip.yaml version: any dir name is allowed. Fill in the
-        # dir name so the bundled mip.json carries the correct version.
-        mip_yaml['version'] = release_version
-        with open(mip_yaml_path, 'w') as f:
-            yaml.safe_dump(mip_yaml, f, sort_keys=False)
+    if mv and release_version != mv and release_version != source_branch:
+        raise ValueError(
+            f"Release directory {release_version!r} must equal mip.yaml "
+            f"version {mv!r} or recipe source.branch {source_branch!r}.")
 
 
 def read_mip_yaml_architectures(mip_yaml_path):
@@ -218,7 +212,8 @@ def read_mip_yaml_architectures(mip_yaml_path):
     return archs, mip_yaml
 
 
-def check_existing_package(mhl_filename, source_hash, mip_yaml):
+def check_existing_package(mhl_filename, source_hash, mip_yaml,
+                           release_version):
     """Check if package already exists in GitHub releases with matching source hash."""
     release_tag = release_tag_from_mhl(mhl_filename)
     base_url = get_base_url(release_tag)
@@ -237,8 +232,12 @@ def check_existing_package(mhl_filename, source_hash, mip_yaml):
             print(f"  Source hash mismatch")
             return False
 
+        if existing.get('version') != release_version:
+            print(f"  Metadata mismatch in 'version'")
+            return False
+
         # Compare key metadata
-        for field in ('name', 'description', 'version', 'dependencies',
+        for field in ('name', 'description', 'dependencies',
                       'homepage', 'repository', 'license'):
             if existing.get(field) != mip_yaml.get(field):
                 print(f"  Metadata mismatch in '{field}'")
@@ -368,7 +367,7 @@ class PackagePreparer:
                     print(f"  Error: No mip.yaml found")
                     return False
 
-                validate_and_apply_version(
+                validate_channel_version_rules(
                     mip_yaml_path, recipe, release_version)
                 archs, mip_yaml = read_mip_yaml_architectures(mip_yaml_path)
             finally:
@@ -389,17 +388,17 @@ class PackagePreparer:
             else:
                 effective_arch = 'any'
 
-            # Build the .mhl filename for cache check. Canonical package
-            # names may contain '-', but the filename uses '-' as a field
-            # separator, so encode the name with '_' in the filename.
-            version = mip_yaml.get('version') or release_version
+            # Build the .mhl filename for cache check. The release-dir
+            # version is authoritative. Canonical package names may contain
+            # '-', but the filename uses '-' as a field separator, so encode
+            # the name with '_' in the filename.
             name_for_filename = mip_yaml['name'].replace('-', '_')
-            mhl_filename = (f"{name_for_filename}-{version}-"
+            mhl_filename = (f"{name_for_filename}-{release_version}-"
                             f"{effective_arch}.mhl")
 
             # Check cache
             if not self.force and check_existing_package(
-                    mhl_filename, source_hash, mip_yaml):
+                    mhl_filename, source_hash, mip_yaml, release_version):
                 print(f"  Skipping - package already up to date")
                 continue
 
@@ -408,7 +407,7 @@ class PackagePreparer:
                 continue
 
             # Create output directory: build/prepared/{name}-{version}/
-            output_name = f"{mip_yaml['name']}-{version}"
+            output_name = f"{mip_yaml['name']}-{release_version}"
             output_path = os.path.join(self.output_dir, output_name)
 
             if os.path.exists(output_path):
@@ -420,11 +419,16 @@ class PackagePreparer:
                 self._fetch_source(recipe, output_path)
                 # Overlay channel files
                 overlay_channel_files(release_folder, output_path)
-                # Fill in mip.yaml's version from the release directory name
-                # when it is blank/missing (channel version rules).
-                validate_and_apply_version(
+                # Validate channel version rules against the source mip.yaml.
+                validate_channel_version_rules(
                     os.path.join(output_path, 'mip.yaml'),
                     recipe, release_version)
+
+                # Write the release-dir version for mip bundle to pick up as
+                # the authoritative version in mip.json.
+                with open(os.path.join(output_path, '.release_version'),
+                          'w') as f:
+                    f.write(release_version)
 
                 # Write source_hash for mip bundle to include in mip.json
                 hash_file = os.path.join(output_path, '.source_hash')

--- a/scripts/prepare_packages.py
+++ b/scripts/prepare_packages.py
@@ -154,16 +154,57 @@ def overlay_channel_files(release_folder, target_dir):
             shutil.copy2(src, dst)
 
 
-def apply_recipe_overrides(mip_yaml_path, recipe):
-    """Apply recipe-level overrides (e.g. version) to mip.yaml on disk."""
-    version_override = recipe.get('version')
-    if version_override is None:
-        return
+def is_numeric_version(s):
+    """Return True if s is a dot-separated numeric version (e.g. '1.2.3')."""
+    if not s:
+        return False
+    parts = s.split('.')
+    return all(p.isdigit() for p in parts) and len(parts) >= 1
+
+
+def validate_and_apply_version(mip_yaml_path, recipe, release_version):
+    """Validate channel version rules and write the release-dir version into
+    mip.yaml when mip.yaml's version is blank or missing.
+
+    Rules:
+    - recipe.yaml must not contain a top-level 'version' field.
+    - If mip.yaml has a non-empty 'version', it must be numeric.
+    - The release-directory name must be one of:
+        * the numeric version in mip.yaml,
+        * the name of 'source.branch' in recipe.yaml, or
+        * anything (if mip.yaml's version is blank/missing).
+    """
+    if 'version' in recipe:
+        raise ValueError(
+            "recipe.yaml must not contain a 'version' field "
+            "(release dir is the version)")
+
     with open(mip_yaml_path, 'r') as f:
         mip_yaml = yaml.safe_load(f) or {}
-    mip_yaml['version'] = version_override
-    with open(mip_yaml_path, 'w') as f:
-        yaml.safe_dump(mip_yaml, f, sort_keys=False)
+    mv = mip_yaml.get('version')
+    if mv is None:
+        mv = ''
+    mv = str(mv).strip()
+
+    source_branch = (recipe.get('source') or {}).get('branch') or ''
+
+    if mv and not is_numeric_version(mv):
+        raise ValueError(
+            f"mip.yaml 'version' must be blank or numeric, got {mv!r}. "
+            f"Non-numeric values (e.g. branch names) belong in the release "
+            f"directory name, not in mip.yaml.")
+
+    if mv:
+        if release_version != mv and release_version != source_branch:
+            raise ValueError(
+                f"Release directory {release_version!r} must equal mip.yaml "
+                f"version {mv!r} or recipe source.branch {source_branch!r}.")
+    else:
+        # Blank/missing mip.yaml version: any dir name is allowed. Fill in the
+        # dir name so the bundled mip.json carries the correct version.
+        mip_yaml['version'] = release_version
+        with open(mip_yaml_path, 'w') as f:
+            yaml.safe_dump(mip_yaml, f, sort_keys=False)
 
 
 def read_mip_yaml_architectures(mip_yaml_path):
@@ -327,7 +368,8 @@ class PackagePreparer:
                     print(f"  Error: No mip.yaml found")
                     return False
 
-                apply_recipe_overrides(mip_yaml_path, recipe)
+                validate_and_apply_version(
+                    mip_yaml_path, recipe, release_version)
                 archs, mip_yaml = read_mip_yaml_architectures(mip_yaml_path)
             finally:
                 if os.path.exists(temp_dir):
@@ -350,7 +392,7 @@ class PackagePreparer:
             # Build the .mhl filename for cache check. Canonical package
             # names may contain '-', but the filename uses '-' as a field
             # separator, so encode the name with '_' in the filename.
-            version = mip_yaml.get('version', release_version)
+            version = mip_yaml.get('version') or release_version
             name_for_filename = mip_yaml['name'].replace('-', '_')
             mhl_filename = (f"{name_for_filename}-{version}-"
                             f"{effective_arch}.mhl")
@@ -378,9 +420,11 @@ class PackagePreparer:
                 self._fetch_source(recipe, output_path)
                 # Overlay channel files
                 overlay_channel_files(release_folder, output_path)
-                # Apply recipe-level overrides (e.g. version) to mip.yaml
-                apply_recipe_overrides(
-                    os.path.join(output_path, 'mip.yaml'), recipe)
+                # Fill in mip.yaml's version from the release directory name
+                # when it is blank/missing (channel version rules).
+                validate_and_apply_version(
+                    os.path.join(output_path, 'mip.yaml'),
+                    recipe, release_version)
 
                 # Write source_hash for mip bundle to include in mip.json
                 hash_file = os.path.join(output_path, '.source_hash')


### PR DESCRIPTION
Implements the channel-side changes for the decision in mip-org/mip#211.

## Summary

- `recipe.yaml` no longer carries a top-level `version` field.
- The release-directory name under `packages/<name>/<version>/` is authoritative.
- `prepare_packages.py` validates that the release-dir name satisfies one of:
  - the numeric `version` in `mip.yaml`,
  - `source.branch` in `recipe.yaml`, or
  - any string, when `mip.yaml`'s `version` is blank/missing.
- When `mip.yaml`'s version is blank/missing, the dir name is written into `mip.yaml` before bundling so the bundled `mip.json` carries the correct version.
- README documents the new rules.

## Coordinated merge

This change must land together with:
- mip-org/mip#218
- mip-org/mip-core#5

Needs approval from @danfortunato.

Other channels (`mip-hello`, `mip-staging`, `mip-magland`, `mip-test-channel1/2`) intentionally not synced yet — trying mip-core first.