### PR TITLE
Rename `addpaths` to `paths` in mip.yaml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ version: "1.0.0"
 license: "MIT"
 dependencies: []
 
-addpaths:
+paths:
   - path: "."
 
 builds:


### PR DESCRIPTION
## Summary
- Updates the `mip.yaml` example in the README to use `paths:` instead of `addpaths:`, matching the rename in the `mip` tool.
- The template sync workflow will propagate this to every channel's README.