### PR TITLE
Auto-update package versions on a daily schedule

### DIFF
--- a/.github/workflows/build-and-upload-packages.yml
+++ b/.github/workflows/build-and-upload-packages.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # Daily at 06:00 UTC. Picks up new commits on branch-pinned packages
+    # via the source-hash check in prepare_packages.py.
+    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       force:

--- a/.github/workflows/check-for-updates.yml
+++ b/.github/workflows/check-for-updates.yml
@@ -1,0 +1,58 @@
+name: Check for package version updates
+
+on:
+  schedule:
+    # Daily at 06:00 UTC, slightly offset from the build workflow.
+    - cron: '15 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml packaging
+
+      - name: Check for new upstream versions
+        run: |
+          python scripts/check_for_updates.py \
+            --summary-file build/auto-update-summary.md
+        shell: bash
+
+      - name: Determine PR body
+        id: pr
+        run: |
+          if [ -s build/auto-update-summary.md ]; then
+            {
+              echo 'body<<__BODY_EOF__'
+              cat build/auto-update-summary.md
+              echo '__BODY_EOF__'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo 'body=No new versions detected.' >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
+      - name: Open or update pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: auto-update-versions
+          delete-branch: true
+          commit-message: "Auto-update: add new package versions"
+          title: "Auto-update: new package versions detected upstream"
+          body: ${{ steps.pr.outputs.body }}
+          add-paths: |
+            packages/**

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ source:
   branch: "main"              # optional
   subdirectory: "matlab"      # optional: extract specific subdir
   remove_dirs: [tests, docs]  # optional: remove after clone
+
+# Optional: control daily auto-update of numeric versions (see below)
+auto_update: true             # default; set to false to opt out
+tag_pattern: "v{version}"     # optional override; usually inferred
 ```
 
 ### mip.yaml — package metadata
@@ -85,6 +89,32 @@ On every push to `main`, GitHub Actions:
 3. **Uploads** packages — stores `.mhl` files as GitHub Release assets
 4. **Assembles index** — collects metadata from all releases into `index.json`
 5. **Deploys** — publishes `index.json` and `packages.html` to GitHub Pages
+
+## Automatic version tracking
+
+A daily GitHub Actions workflow keeps the channel current with upstream:
+
+- **Branch packages** (e.g. `packages/foo/main/`) — the build workflow runs
+  on a daily cron and rebuilds whenever upstream's branch HEAD has advanced.
+  No directory changes are needed; new commits flow through to GitHub Release
+  assets automatically.
+- **Numeric versions** (e.g. `packages/chebfun/5.7.0/`) — a separate
+  `check-for-updates` workflow lists upstream tags, detects new numeric
+  versions higher than the highest existing dir, and opens a pull request
+  adding `packages/<name>/<new_version>/`. Merging the PR triggers a build.
+
+### Tag pattern resolution
+
+To map an upstream tag (e.g. `v5.8.0`) to a numeric version (`5.8.0`),
+the workflow tries, in order:
+
+1. `tag_pattern` field on the reference recipe, if set.
+2. Inference from the highest-numeric existing dir's `source.branch`
+   (e.g. dir `5.7.0` with `source.branch: v5.7.0` → pattern `v{version}`).
+3. Auto-detection from upstream tags (majority of `v`-prefixed vs bare).
+
+Set `auto_update: false` on the reference recipe to opt out of automatic
+PRs (e.g. for packages intentionally pinned to an old version).
 
 ## Using this channel in MATLAB
 

--- a/scripts/check_for_updates.py
+++ b/scripts/check_for_updates.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""
+Auto-update package versions by detecting new upstream tags.
+
+For each package directory under packages/:
+1. Find the reference recipe (highest-numeric version dir or first branch dir).
+2. Skip if the reference recipe sets `auto_update: false`.
+3. Query upstream git tags via `git ls-remote --tags`.
+4. Determine the tag pattern: explicit `tag_pattern`, inferred from the
+   reference recipe's `source.branch`, or auto-detected from upstream tags.
+5. Find numeric versions newer than the highest existing numeric dir.
+6. Create `packages/<name>/<version>/` for each new version, with
+   updated `recipe.yaml` (`source.branch` -> tag) and `mip.yaml`
+   (`version` -> the new numeric version, if a channel-side mip.yaml exists).
+"""
+
+import os
+import sys
+import re
+import shutil
+import subprocess
+import argparse
+import yaml
+from packaging.version import Version, InvalidVersion
+
+
+VERSION_TAG_RE = re.compile(r'^(v?)(\d+(?:\.\d+){0,2})$')
+
+
+def is_numeric_version(s):
+    """Return True if s is a dot-separated numeric version (e.g. '1.2.3')."""
+    if not s:
+        return False
+    parts = s.split('.')
+    return all(p.isdigit() for p in parts) and len(parts) >= 1
+
+
+def list_release_dirs(package_dir):
+    """List release dir names that contain a recipe.yaml."""
+    result = []
+    for name in sorted(os.listdir(package_dir)):
+        full = os.path.join(package_dir, name)
+        if not os.path.isdir(full):
+            continue
+        if not os.path.exists(os.path.join(full, 'recipe.yaml')):
+            continue
+        result.append(name)
+    return result
+
+
+def pick_reference_dir(release_dirs):
+    """Pick the reference release dir: highest-numeric, else first non-numeric."""
+    numeric = [d for d in release_dirs if is_numeric_version(d)]
+    if numeric:
+        return max(numeric, key=Version)
+    if release_dirs:
+        return release_dirs[0]
+    return None
+
+
+def load_yaml(path):
+    with open(path, 'r') as f:
+        return yaml.safe_load(f) or {}
+
+
+def list_remote_tags(git_url):
+    """Return list of tag short-names from git ls-remote --tags."""
+    proc = subprocess.run(
+        ['git', 'ls-remote', '--tags', git_url],
+        capture_output=True, text=True, check=True,
+    )
+    tags = []
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            _hash, ref = line.split('\t', 1)
+        except ValueError:
+            continue
+        if not ref.startswith('refs/tags/'):
+            continue
+        # Annotated-tag dereference suffix points to the same logical tag.
+        if ref.endswith('^{}'):
+            continue
+        tags.append(ref[len('refs/tags/'):])
+    return tags
+
+
+def detect_pattern_from_tags(tags):
+    """Return the dominant `v{version}` vs `{version}` shape, or None."""
+    v_count = 0
+    bare_count = 0
+    for tag in tags:
+        m = VERSION_TAG_RE.match(tag)
+        if not m:
+            continue
+        if m.group(1) == 'v':
+            v_count += 1
+        else:
+            bare_count += 1
+    if v_count == 0 and bare_count == 0:
+        return None
+    return 'v{version}' if v_count >= bare_count else '{version}'
+
+
+def infer_pattern_from_recipe(recipe, ref_version):
+    """Locate ref_version inside source.branch and substitute {version}."""
+    source = recipe.get('source') or {}
+    branch = source.get('branch')
+    if not branch or not ref_version:
+        return None
+    if ref_version not in branch:
+        return None
+    return branch.replace(ref_version, '{version}')
+
+
+def resolve_pattern(reference_recipe, ref_version, upstream_tags):
+    """Return (pattern_string, source_kind) where source_kind is one of
+    'explicit', 'inferred', 'detected', or (None, None) if no pattern."""
+    explicit = reference_recipe.get('tag_pattern')
+    if explicit:
+        return explicit, 'explicit'
+
+    if ref_version and is_numeric_version(ref_version):
+        inferred = infer_pattern_from_recipe(reference_recipe, ref_version)
+        if inferred:
+            return inferred, 'inferred'
+
+    detected = detect_pattern_from_tags(upstream_tags)
+    if detected:
+        return detected, 'detected'
+
+    return None, None
+
+
+def pattern_to_regex(pattern):
+    """Compile a tag pattern (with {version}) into a regex anchored full-match."""
+    placeholder = '__VERSION_PLACEHOLDER__'
+    escaped = re.escape(pattern.replace('{version}', placeholder))
+    body = escaped.replace(placeholder, r'(\d+(?:\.\d+){0,2})')
+    return re.compile('^' + body + '$')
+
+
+def find_new_versions(tags, pattern, current_highest):
+    """Return list of (version_str, tag) for tags newer than current_highest."""
+    pat_re = pattern_to_regex(pattern)
+    found = []
+    for tag in tags:
+        m = pat_re.match(tag)
+        if not m:
+            continue
+        version_str = m.group(1)
+        try:
+            v = Version(version_str)
+        except InvalidVersion:
+            continue
+        if current_highest is not None and v <= current_highest:
+            continue
+        found.append((v, version_str, tag))
+    found.sort(key=lambda x: x[0])
+    return [(vs, t) for _v, vs, t in found]
+
+
+def update_recipe_yaml(path, new_branch):
+    """Set source.branch in recipe.yaml to the resolved tag."""
+    data = load_yaml(path)
+    source = data.get('source')
+    if not isinstance(source, dict):
+        source = {}
+        data['source'] = source
+    source['branch'] = new_branch
+    with open(path, 'w') as f:
+        yaml.safe_dump(data, f, sort_keys=False)
+
+
+def update_mip_yaml_if_present(path, new_version):
+    """If a channel-side mip.yaml exists, set its version to new_version."""
+    if not os.path.exists(path):
+        return False
+    data = load_yaml(path)
+    data['version'] = str(new_version)
+    with open(path, 'w') as f:
+        yaml.safe_dump(data, f, sort_keys=False)
+    return True
+
+
+def process_package(package_dir, dry_run=False):
+    package_name = os.path.basename(package_dir)
+    print(f"\nProcessing package: {package_name}")
+
+    release_dirs = list_release_dirs(package_dir)
+    if not release_dirs:
+        print(f"  No release dirs with recipe.yaml, skipping")
+        return []
+
+    ref_dir_name = pick_reference_dir(release_dirs)
+    ref_path = os.path.join(package_dir, ref_dir_name)
+    ref_recipe = load_yaml(os.path.join(ref_path, 'recipe.yaml'))
+
+    if ref_recipe.get('auto_update') is False:
+        print(f"  auto_update: false on reference recipe, skipping")
+        return []
+
+    source = ref_recipe.get('source') or {}
+    git_url = source.get('git')
+    if not git_url:
+        print(f"  No source.git on reference recipe, skipping "
+              f"(only git-sourced packages are auto-updated)")
+        return []
+
+    print(f"  Reference dir: {ref_dir_name}")
+    print(f"  Upstream: {git_url}")
+
+    try:
+        tags = list_remote_tags(git_url)
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or '').strip() if hasattr(e, 'stderr') else ''
+        print(f"  Error listing remote tags: {e}\n    {stderr}")
+        return []
+
+    if not tags:
+        print(f"  Upstream has no tags, skipping")
+        return []
+
+    ref_version = ref_dir_name if is_numeric_version(ref_dir_name) else None
+    pattern, source_kind = resolve_pattern(ref_recipe, ref_version, tags)
+    if not pattern:
+        print(f"  Could not determine tag pattern, skipping")
+        return []
+
+    print(f"  Tag pattern ({source_kind}): {pattern}")
+
+    numeric_dirs = [d for d in release_dirs if is_numeric_version(d)]
+    current_highest = max((Version(d) for d in numeric_dirs), default=None)
+    if current_highest is not None:
+        print(f"  Current highest numeric version: {current_highest}")
+    else:
+        print(f"  No existing numeric versions")
+
+    new_versions = find_new_versions(tags, pattern, current_highest)
+    if not new_versions:
+        print(f"  No new versions found")
+        return []
+
+    created = []
+    for version_str, tag in new_versions:
+        new_dir = os.path.join(package_dir, version_str)
+        if os.path.exists(new_dir):
+            print(f"  {version_str} already exists, skipping")
+            continue
+        verb = '[DRY RUN] Would create' if dry_run else 'Creating'
+        print(f"  {verb}: packages/{package_name}/{version_str}/ "
+              f"(from tag {tag})")
+        if not dry_run:
+            shutil.copytree(ref_path, new_dir)
+            update_recipe_yaml(os.path.join(new_dir, 'recipe.yaml'), tag)
+            mip_yaml_path = os.path.join(new_dir, 'mip.yaml')
+            if update_mip_yaml_if_present(mip_yaml_path, version_str):
+                print(f"    Updated mip.yaml version -> {version_str}")
+        created.append((package_name, version_str, tag))
+
+    return created
+
+
+def process_all(packages_dir, dry_run=False):
+    package_names = sorted(
+        d for d in os.listdir(packages_dir)
+        if os.path.isdir(os.path.join(packages_dir, d))
+    )
+    all_created = []
+    for name in package_names:
+        all_created.extend(
+            process_package(os.path.join(packages_dir, name), dry_run))
+    return all_created
+
+
+def write_summary(path, created):
+    with open(path, 'w') as f:
+        if not created:
+            f.write("No new package versions detected.\n")
+            return
+        f.write("Auto-update detected new upstream versions:\n\n")
+        for name, version, tag in created:
+            f.write(f"- `{name}` → `{version}` (upstream tag `{tag}`)\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Print what would be done without writing files')
+    parser.add_argument('--package', type=str,
+                        help='Process only this package')
+    parser.add_argument('--packages-dir', type=str,
+                        help='Override packages directory (for testing)')
+    parser.add_argument('--summary-file', type=str,
+                        help='Write a Markdown summary of created versions')
+    args = parser.parse_args()
+
+    if args.packages_dir:
+        packages_dir = args.packages_dir
+    else:
+        project_root = os.path.dirname(
+            os.path.dirname(os.path.abspath(__file__)))
+        packages_dir = os.path.join(project_root, 'packages')
+
+    if not os.path.isdir(packages_dir):
+        print(f"No packages directory at {packages_dir}, nothing to do")
+        if args.summary_file:
+            write_summary(args.summary_file, [])
+        return 0
+
+    if args.package:
+        package_dir = os.path.join(packages_dir, args.package)
+        if not os.path.isdir(package_dir):
+            print(f"Package not found: {args.package}")
+            return 1
+        created = process_package(package_dir, dry_run=args.dry_run)
+    else:
+        created = process_all(packages_dir, dry_run=args.dry_run)
+
+    print()
+    if not created:
+        print("No new versions detected.")
+    else:
+        print(f"Detected {len(created)} new version(s):")
+        for name, version, tag in created:
+            print(f"  {name} {version} (tag: {tag})")
+
+    if args.summary_file:
+        write_summary(args.summary_file, created)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Closes #10.

## Summary

- Adds a daily cron (`schedule:`) to the existing build workflow so branch-pinned packages rebuild when upstream HEAD advances. No code changes needed — `prepare_packages.py` already folds branch commit hashes into the source hash, so unchanged packages skip via the existing cache.
- New `scripts/check_for_updates.py` + `.github/workflows/check-for-updates.yml`. The script lists upstream tags, picks new numeric versions, and the workflow opens a single consolidated PR adding `packages/<name>/<new_version>/` directories.

## Tag pattern resolution

For each package, the script picks the highest-numeric existing dir as the *reference recipe*, then resolves how upstream tags map to numeric versions, in order:

1. Explicit `tag_pattern` on the reference recipe.
2. Inference from the reference recipe's `source.branch` (e.g. dir `5.7.0` with `branch: v5.7.0` → `v{version}`).
3. Auto-detection from upstream tags (majority of `v`-prefixed vs. bare). Used as a fallback when the package is branch-only.

Recipes can opt out of auto-PRs via `auto_update: false`. Pre-release tags (`-rc`, `-beta`, etc.) are filtered by a strict numeric regex before sorting.

## Test plan

- [x] Pattern inference: `branch: v5.5.0` → `v{version}`
- [x] Catch-up: reference 5.5.0 + chebfun upstream → 5.6.0 and 5.7.0 both detected
- [x] Real file creation: `recipe.yaml` updates `source.branch`, `mip.yaml` updates `version`
- [x] `auto_update: false` skipped
- [x] Explicit `tag_pattern` override
- [x] Branch-only package falls back to detection
- [x] Pre-release tags rejected (`-rc1`, `-beta`, `-alpha`, `-pre`, `.dev1`)
- [x] Custom prefix patterns (e.g. `chebfun-{version}`)
- [x] Non-git source (zip) skipped gracefully
- [x] Numeric ordering matches `mip.resolve.compare_versions` for the filtered domain
- [ ] End-to-end: trigger `check-for-updates.yml` via `workflow_dispatch` post-merge and confirm a PR opens